### PR TITLE
Fixed navbar bug in mobile by changing jquery version

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -70,7 +70,7 @@
     <li id="openiit.html"><a href='openiit.html'>Open IIT</a></li>
     <li id="gc-results.html"><a href="gc-results.html">GC 19-20</a></li>
     <li id="messmenu.html"><a href="messmenu.html">Messmenu</a></li>
-    <li id="rulebook.html"><a href='rulebook.html'>Rulebook</a></li>
+    <!-- <li id="rulebook.html"><a href='rulebook.html'>Rulebook</a></li> -->
     <li id="gc.php"><a href="gc.php">GC 18-19</a></li>
     <li id="interiit.php"><a href="interiit.php">Inter IIT</a></li>
     <li id="fests.html"><a href="fests.html">Fests</a></li>

--- a/header.html
+++ b/header.html
@@ -1,7 +1,7 @@
 
 <nav class="navigation">
     <div class="nav-wrapper">
-        <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>
+        <a  data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>
         <a href="index.php" class="brand-logo left valign-wrapper">
             <img src="./static/images/IIT_Kharagpur_Logo.svg" alt="" class="responsive-img">
             <!-- <span id="tsg-banner">Technology Students’ Gymkhana</span> -->
@@ -92,7 +92,7 @@
 <script type="text/javascript" src="js/index.js"></script>
 <script type="text/javascript" src="js/tabs.js"></script>
 <script
-    src="https://code.jquery.com/jquery-3.3.1.js"
+    src="https://code.jquery.com/jquery-2.2.4.js"
     integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60="
     crossorigin="anonymous">
 </script>


### PR DESCRIPTION
Changes made: 
- Changed jquery version to 2.2.4 to make compatibe with materialiize, refer [this](https://stackoverflow.com/questions/43994931/typeerror-sidenav-is-not-a-function)
- removed `href="#"` in the navbar icon in mobile
- Commented rule book link in the navbar as its  page was messed, see #55 

*While testing, sometimes the navbar deck used to open sometimes doesn't, I am assuming that it is due to my mousepad of my laptop, once need to be tested properly on production on mobile*